### PR TITLE
build(mirror): Define GitLab mirror in source

### DIFF
--- a/.gitlab/repository.json
+++ b/.gitlab/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "terraform-aws-sqs-ecs-autoscaling",
-  "url": "https://gitlab.com/infraprints/terraform-aws-sqs-ecs-autoscaling",
+  "url": "https://gitlab.com/infraprints/modules/terraform-aws-sqs-ecs-autoscaling",
   "status": "mirror"
 }

--- a/.gitlab/repository.json
+++ b/.gitlab/repository.json
@@ -1,0 +1,5 @@
+{
+  "name": "terraform-aws-sqs-ecs-autoscaling",
+  "url": "https://gitlab.com/infraprints/terraform-aws-sqs-ecs-autoscaling",
+  "status": "mirror"
+}


### PR DESCRIPTION
Configure the gitlab repository target in source.

Create a reference to the GitLab mirror location of this repository is source. Although it would be nice to not bundle in the references to the location of a repository into the repository, there exists leakiness in other ways in the repositories. This is done to assist in some cross-service mirroring experiments.